### PR TITLE
Add support for 'psr/log' 2.0 and 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=7.1|>=8.0",
         "rtheunissen/cache": "~0.1",
         "guzzlehttp/guzzle": "~6.0|~7.0",
-        "psr/log": "~1.0"
+        "psr/log": "~1.0|~2.0|~3.0"
     },
     "require-dev": {
         "doctrine/cache": "~1.4",


### PR DESCRIPTION
Hi,

This PR adds 'psr/log' versions 2.0 and 3.0 to the package.

All tests keep passing.

Thanks