### PR TITLE
Fix deprecation with implicitly marking parameter as nullable

### DIFF
--- a/src/CacheHandler.php
+++ b/src/CacheHandler.php
@@ -339,11 +339,11 @@ class CacheHandler
      * be cached.
      *
      * @param Request  $request  The request to filter.
-     * @param Response $response The response to filter, if any.
+     * @param Response|null $response The response to filter, if any.
      *
      * @return bool true if should be cached, false otherwise.
      */
-    protected function filter(Request $request, Response $response = null)
+    protected function filter(Request $request, ?Response $response = null)
     {
         $filter = $this->options['filter'];
         if ($filter) {


### PR DESCRIPTION
PHP 8.4 deprecates implicitly nullable types. PHP applications are recommended to explicitly declare the type as nullable. All type declarations that have a default value of null, but without declaring null in the type declaration emit a deprecation notice.

Source: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated